### PR TITLE
Remove Crypto import and update tests

### DIFF
--- a/ska_ftp/ftp.py
+++ b/ska_ftp/ftp.py
@@ -59,10 +59,7 @@ class SFTP(object):
     :param logger: logger object (e.g. pyyaks.logger.get_logger())
     """
     def __init__(self, host, user=None, passwd=None, netrcfile=None, logger=None):
-        import Crypto.pct_warnings
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', Crypto.pct_warnings.PowmInsecureWarning)
-            import paramiko
+        import paramiko
 
         auths = parse_netrc(netrcfile)
         if host in auths:

--- a/ska_ftp/tests/conftest.py
+++ b/ska_ftp/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import ska_ftp
 
+
 @pytest.fixture()
-def NETRC():
+def parsed_netrc():
     return ska_ftp.parse_netrc()

--- a/ska_ftp/tests/conftest.py
+++ b/ska_ftp/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+import ska_ftp
+
+@pytest.fixture()
+def NETRC():
+    return ska_ftp.parse_netrc()

--- a/ska_ftp/tests/test_basic.py
+++ b/ska_ftp/tests/test_basic.py
@@ -10,11 +10,10 @@ import pytest
 
 logger = pyyaks.logger.get_logger()
 
-NETRC = ska_ftp.parse_netrc()
 LUCKY = 'lucky.cfa.harvard.edu'
 
 
-def roundtrip(FtpClass, logger=None):
+def roundtrip(NETRC, FtpClass, logger=None):
     user = NETRC[LUCKY]['login']
     homedir = ('/home/' if FtpClass is ska_ftp.SFTP else '/') + user
     lucky = FtpClass(LUCKY, logger=logger)
@@ -42,17 +41,17 @@ def roundtrip(FtpClass, logger=None):
     assert orig == roundtrip
 
 
-def test_roundtrip():
+def test_roundtrip(NETRC):
     # roundtrip(FtpClass=ska_ftp.FTP, logger=logger)  # legacy of non-secure ftp
-    roundtrip(FtpClass=ska_ftp.SFTP, logger=logger)
+    roundtrip(NETRC, FtpClass=ska_ftp.SFTP, logger=logger)
 
 
-def test_roundtrip_no_logger():
+def test_roundtrip_no_logger(NETRC):
     # roundtrip(FtpClass=ska_ftp.FTP)
-    roundtrip(FtpClass=ska_ftp.SFTP)
+    roundtrip(NETRC, FtpClass=ska_ftp.SFTP)
 
 
-def test_sftp_mkdir_rmdir_rename():
+def test_sftp_mkdir_rmdir_rename(NETRC):
     user = NETRC[LUCKY]['login']
     homedir = '/home/{}'.format(user)
     lucky = ska_ftp.SFTP(LUCKY, logger=logger)

--- a/ska_ftp/tests/test_basic.py
+++ b/ska_ftp/tests/test_basic.py
@@ -90,7 +90,7 @@ def test_delete_when_ftp_session_already_gone(capfd):
 def test_parse_netrc():
     cwd = os.path.dirname(__file__)
     netrc = ska_ftp.parse_netrc(os.path.join(cwd, 'netrc'))
-    assert netrc == {'test1': {'account': None,
+    assert netrc == {'test1': {'account': '',
                                'login': 'test1_login',
                                'password': 'test1_password'},
                      'test2': {'account': 'test2_account',

--- a/ska_ftp/tests/test_basic.py
+++ b/ska_ftp/tests/test_basic.py
@@ -13,8 +13,8 @@ logger = pyyaks.logger.get_logger()
 LUCKY = "lucky.cfa.harvard.edu"
 
 
-def roundtrip(parsed_netrc, FtpClass, logger=None):
-    user = parsed_netrc[LUCKY]["login"]
+def roundtrip(user_netrc, FtpClass, logger=None):
+    user = user_netrc[LUCKY]["login"]
     homedir = ("/home/" if FtpClass is ska_ftp.SFTP else "/") + user
     lucky = FtpClass(LUCKY, logger=logger)
     lucky.cd(homedir)

--- a/ska_ftp/tests/test_basic.py
+++ b/ska_ftp/tests/test_basic.py
@@ -13,10 +13,10 @@ logger = pyyaks.logger.get_logger()
 LUCKY = "lucky.cfa.harvard.edu"
 
 
-def roundtrip(user_netrc, FtpClass, logger=None):
+def roundtrip(user_netrc, ftp_cls, logger=None):
     user = user_netrc[LUCKY]["login"]
-    homedir = ("/home/" if FtpClass is ska_ftp.SFTP else "/") + user
-    lucky = FtpClass(LUCKY, logger=logger)
+    homedir = ("/home/" if ftp_cls is ska_ftp.SFTP else "/") + user
+    lucky = ftp_cls(LUCKY, logger=logger)
     lucky.cd(homedir)
     files_before = lucky.ls()
 
@@ -42,13 +42,13 @@ def roundtrip(user_netrc, FtpClass, logger=None):
 
 
 def test_roundtrip(parsed_netrc):
-    # roundtrip(FtpClass=ska_ftp.FTP, logger=logger)  # legacy of non-secure ftp
-    roundtrip(parsed_netrc, FtpClass=ska_ftp.SFTP, logger=logger)
+    # roundtrip(ftp_cls=ska_ftp.FTP, logger=logger)  # legacy of non-secure ftp
+    roundtrip(parsed_netrc, ftp_cls=ska_ftp.SFTP, logger=logger)
 
 
 def test_roundtrip_no_logger(parsed_netrc):
-    # roundtrip(FtpClass=ska_ftp.FTP)
-    roundtrip(parsed_netrc, FtpClass=ska_ftp.SFTP)
+    # roundtrip(ftp_cls=ska_ftp.FTP)
+    roundtrip(parsed_netrc, ftp_cls=ska_ftp.SFTP)
 
 
 def test_sftp_mkdir_rmdir_rename(parsed_netrc):


### PR DESCRIPTION
## Description

Remove Crypto import and update tests.

Crypto isn't available for Python 3.11 and we weren't really using it anyway.  A more fundamental issue is that it looks like netrc.netrc is now returning empty string instead of None if a value isn't in the netrc, so this isn't 100% back-compatible behavior (and the test isn't back-compatible).

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes issue like
```
FAILED ska_ftp/tests/test_basic.py::test_roundtrip - ModuleNotFoundError: No module named 'Crypto'
```
on Python 3.11 test build.  May have more warnings again on Python 3.10 build but we catch those with pytest.ini anyway.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
test_parse_netrc has been updated for netrc version >= 3.10 which returns empty string instead of None and is not compatible with current ska3-flight.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac with ska3-flight-2024.0rc7 and ska3-masters

```
(ska3-flight-2024.0rc7) flame:ska_ftp jean$ pytest
=============================================================================== test session starts ===============================================================================
platform darwin -- Python 3.11.7, pytest-7.4.4, pluggy-1.3.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.2.0
collected 7 items                                                                                                                                                                 

ska_ftp/tests/test_basic.py .......                                                                                                                                         [100%]

================================================================================ warnings summary =================================================================================
../../miniconda3/envs/ska3-flight-2024.0rc7/lib/python3.11/site-packages/ska_helpers/version.py:25
  /Users/jean/miniconda3/envs/ska3-flight-2024.0rc7/lib/python3.11/site-packages/ska_helpers/version.py:25: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import DistributionNotFound, get_distribution

../../miniconda3/envs/ska3-flight-2024.0rc7/lib/python3.11/site-packages/pkg_resources/__init__.py:2868
  /Users/jean/miniconda3/envs/ska3-flight-2024.0rc7/lib/python3.11/site-packages/pkg_resources/__init__.py:2868: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('sphinxcontrib')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================== 7 passed, 2 warnings in 4.91s
```


```
(ska3) flame:ska_ftp jean$ git rev-parse HEAD
10d5a14abe9b464c38f9211ee68b32aaa8c31bb2
(ska3) flame:ska_ftp jean$ pytest
=============================================================================== test session starts ===============================================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/jean/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 7 items                                                                                                                                                                 

ska_ftp/tests/test_basic.py .......                                                                                                                                         [100%]

================================================================================ 7 passed in 3.34s
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
